### PR TITLE
固定pygments包版本，解决构建失败问题

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs 
 mkdocs-material==4.6.3
 pymdown-extensions==6.3
+Pygments==2.11.0


### PR DESCRIPTION
pygments包升级了，似乎新版本的不能兼容。现在测试的这个版本可行。