### PR TITLE
版本固定

### DIFF
--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -8,11 +8,11 @@ on:
 # Reference: https://github.com/marketplace/actions/deploy-mkdocs
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Deploy to GitHub Pages
-        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        uses: YanhuiJessica/mkdocs-deploy-gh-pages@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REQUIREMENTS: requirements.txt


### PR DESCRIPTION
- 固定 `ubuntu` 及 `mkdocs-deploy-gh-pages` 使用的版本，避免更新可能带来的问题
- fork 仓库[测试通过](https://github.com/YanhuiJessica/acm-wiki/runs/6381060665?check_suite_focus=true)