### PR TITLE
Fix: Code Block Rendering Bug

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -181,9 +181,6 @@ extra_css:
 # Extensions
 markdown_extensions:
   - admonition
-  - codehilite:
-      guess_lang: false
-      linenums: true
   - def_list
   - footnotes
   - meta
@@ -196,7 +193,7 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_generator: !!python/name:pymdownx.emoji.to_svg
   - pymdownx.highlight:
-    linenums: true
+      linenums: true
   - pymdownx.inlinehilite
   - pymdownx.keys
   - pymdownx.magiclink

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -195,6 +195,8 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.emoji:
       emoji_generator: !!python/name:pymdownx.emoji.to_svg
+  - pymdownx.highlight:
+    linenums: true
   - pymdownx.inlinehilite
   - pymdownx.keys
   - pymdownx.magiclink

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mkdocs 
 mkdocs-material==4.6.3
 pymdown-extensions==10.0
-Pygments==2.11.0
+Pygments==2.15.1


### PR DESCRIPTION
Commit ee4b814cdf852c5122a0a6fb335dd2a8dc731d83  将pymdown-extensions 从6.3 升级至10.0，这会导致当前代码块渲染错误。

<img width="709" alt="image" src="https://github.com/CUCCS/acm-wiki/assets/44770303/25e92a22-4d85-4897-80bf-282ef33e739d">



解决办法为，将 `Pygments` 对应升级至2.15.1，同时由于行号不再默认显示，添加 `pymdownx.highlight`，删除[过期的插件](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#codehilite)`codehilite`。在本地测试通过。